### PR TITLE
Fix css path and screensharing button

### DIFF
--- a/JS/sample-app/public/index.html
+++ b/JS/sample-app/public/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="images/favicon.png">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="css/opentok-style.css">
+    <link rel="stylesheet" href="css/styles.css">
 
     <!-- JS -->
     <script src="https://static.opentok.com/v2/js/opentok.min.js" type="text/javascript" defer></script>

--- a/JS/sample-app/public/js/components/screenshare-annotation-acc-pack.js
+++ b/JS/sample-app/public/js/components/screenshare-annotation-acc-pack.js
@@ -467,7 +467,7 @@
         if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
     }
     return null;
-  } 
+  }
 
   var _generateUuid = function() {
 
@@ -489,19 +489,19 @@
 
     // init the analytics logs
     var _source = window.location.href;
-    
+
     var _guid = _readCookie('guidAVCommunication')
     if ( !_guid) {
       _createCookie('guidAVCommunication', _generateUuid(), 7);
-    }  
-   
+    }
+
     var otkanalyticsData = {
       clientVersion: _logEventData.clientVersion,
       source: _source,
       componentId: _logEventData.componentId,
       guid: _guid
     };
-    
+
     _otkanalytics = new OTKAnalytics(otkanalyticsData);
     var sessionInfo = {
       sessionId: _session.id,
@@ -510,7 +510,7 @@
     }
 
     _otkanalytics.addSessionInfo(sessionInfo);
-  
+
   };
 
   var _log = function (action, variation) {
@@ -820,7 +820,7 @@
   var _session; // OpenTok session
 
   var _screenSharingControl = [
-    '<div class="video-control circle share-screen" id="startScreenSharing"></div>'
+    '<div class="ots-video-control circle share-screen" id="startScreenSharing"></div>'
   ].join('\n');
 
   var _screenSharingView = [


### PR DESCRIPTION
## What's in this pull request?

1. The path to the css was broken; `css/opentok-style.css` does not exist. `css/styles.css` appears to be the correct replacement, although `css/theme.css` is a bit of an enigma and maybe also should be included.

2. Adds the `ots-` prefix to the screensharing icon div. Without this the icon is invisible.